### PR TITLE
Fix simulator detection in compile time

### DIFF
--- a/PPJailbreakDetection/Classes/PPJailbreakDetection.m
+++ b/PPJailbreakDetection/Classes/PPJailbreakDetection.m
@@ -45,7 +45,7 @@ bool isSandBoxOkay()
 
 + (BOOL)isJailbroken
 {
-#if !(TARGET_IOS_SIMULATOR)
+#if !(TARGET_OS_SIMULATOR)
     if (jailbrokenFileSystem()) {
         return YES;
     }


### PR DESCRIPTION
The correct macro is `TARGET_OS_SIMULATOR` and not `TARGET_IOS_SIMULATOR`